### PR TITLE
Test

### DIFF
--- a/src/conf/domain_conf.c
+++ b/src/conf/domain_conf.c
@@ -19902,7 +19902,6 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
                                                        ctxt,
                                                        nodes[i],
                                                        flags);
-
         if (!chr)
             return NULL;
 
@@ -19911,7 +19910,7 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
         // Giving precedence to the isa-serial device since
         // only limited ports can be used for such devices.
         if (chr->targetType == VIR_DOMAIN_CHR_SERIAL_TARGET_MODEL_ISA_SERIAL) {
-            // Taking the isa serial deivces to start of the array.
+            // Taking the isa serial devices to start of the array.
             for (j = def->nserials; j > isa_serial_count; j--)
                 def->serials[j] = def->serials[j-1];
             def->serials[isa_serial_count++] = chr;
@@ -19919,13 +19918,13 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
 
         // Maintaining the buffer for first max_available_isa_serial_ports unused ports.
         if (chr->target.port != -1 && chr->target.port <= max_available_isa_serial_ports) {
-            if (used_serial_port_buffer & (1<<chr->target.port)) {
+            if (used_serial_port_buffer & (1 << chr->target.port)) {
                 virReportError(VIR_ERR_INTERNAL_ERROR,
                     _("target port [%d] already allocated."),
                     chr->target.port);
                 return NULL;
             }
-            used_serial_port_buffer |= 1<<chr->target.port;
+            used_serial_port_buffer |= 1 << chr->target.port;
         }
 
         // Update max serial port used.
@@ -19941,7 +19940,7 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
         if (def->serials[i]->targetType == VIR_DOMAIN_CHR_SERIAL_TARGET_MODEL_ISA_SERIAL) {
 
             // Search for the next available port.
-            while (used_serial_port_buffer & (1<<next_available_serial_port) &&
+            while (used_serial_port_buffer & (1 << next_available_serial_port) &&
                 next_available_serial_port <= max_available_isa_serial_ports) {
                 next_available_serial_port++;
             }
@@ -19955,7 +19954,7 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
                 return NULL;
             }
 
-            used_serial_port_buffer |= 1<<next_available_serial_port;
+            used_serial_port_buffer |= 1 << next_available_serial_port;
             def->serials[i]->target.port = next_available_serial_port;
 
             // Update max serial port used.

--- a/src/conf/domain_conf.c
+++ b/src/conf/domain_conf.c
@@ -19663,6 +19663,10 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
     g_autofree xmlNodePtr *nodes = NULL;
     g_autofree char *tmp = NULL;
     g_autoptr(virDomainDef) def = NULL;
+    int max_available_isa_serial_ports = 4;
+    long long int used_serial_port_buffer = 0;
+    int isa_serial_count = 0;
+    int next_available_serial_port = 0;
 
     if (!(def = virDomainDefNew(xmlopt)))
         return NULL;
@@ -19897,19 +19901,69 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
                                                        ctxt,
                                                        nodes[i],
                                                        flags);
+
         if (!chr)
             return NULL;
 
-        if (chr->target.port == -1) {
+        def->serials[def->nserials++] = chr;
+
+        // Giving precedence to the isa-serial device since
+        // only limited ports can be used for such devices.
+        if (chr->targetType == VIR_DOMAIN_CHR_SERIAL_TARGET_MODEL_ISA_SERIAL) {
+            // Taking the isa serial deivces to start of the array.
+            for (j = def->nserials; j > isa_serial_count; j--)
+                def->serials[j] = def->serials[j-1];
+            def->serials[isa_serial_count++] = chr;
+        }
+
+        // Maintaining the buffer for first max_available_isa_serial_ports unused ports.
+        if (chr->target.port != -1 && chr->target.port <= max_available_isa_serial_ports) {
+            if (used_serial_port_buffer & (1<<chr->target.port)) {
+                virReportError(VIR_ERR_INTERNAL_ERROR,
+                    _("target port [%d] already allocated."),
+                    chr->target.port);
+                return NULL;
+            }
+            used_serial_port_buffer |= 1<<chr->target.port;
+        }
+    }
+
+    // Assign the ports to the devices.
+    for (i = 0; i < n; i++) {
+        if (def->serials[i]->target.port != -1) continue;
+
+        // Assign one of the unused ports from first max_available_isa_serial_ports ports
+        // to isa-serial device.
+        if (def->serials[i]->targetType == VIR_DOMAIN_CHR_SERIAL_TARGET_MODEL_ISA_SERIAL) {
+
+            // Search for the next available port.
+            while (used_serial_port_buffer & (1<<next_available_serial_port) &&
+                next_available_serial_port <= max_available_isa_serial_ports) {
+                next_available_serial_port++;
+            }
+
+            // qemu doesn't support more than max_available_isa_serial_ports isa devices.
+            if (i > max_available_isa_serial_ports ||
+                next_available_serial_port > max_available_isa_serial_ports) {
+                virReportError(VIR_ERR_INTERNAL_ERROR,
+                    _("Maximum supported number of ISA serial ports is %d."),
+                    max_available_isa_serial_ports);
+                return NULL;
+            }
+
+            used_serial_port_buffer |= 1<<next_available_serial_port;
+            def->serials[i]->target.port = next_available_serial_port;
+
+        } else {
             int maxport = -1;
             for (j = 0; j < i; j++) {
                 if (def->serials[j]->target.port > maxport)
                     maxport = def->serials[j]->target.port;
             }
-            chr->target.port = maxport + 1;
+            def->serials[i]->target.port = maxport + 1;
         }
-        def->serials[def->nserials++] = chr;
     }
+
     VIR_FREE(nodes);
 
     if ((n = virXPathNodeSet("./devices/console", ctxt, &nodes)) < 0) {

--- a/src/conf/domain_conf.c
+++ b/src/conf/domain_conf.c
@@ -65,6 +65,7 @@
 #include "virutil.h"
 
 #define VIR_FROM_THIS VIR_FROM_DOMAIN
+#define max_available_isa_serial_ports 4
 
 VIR_LOG_INIT("conf.domain_conf");
 
@@ -19663,8 +19664,7 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
     g_autofree xmlNodePtr *nodes = NULL;
     g_autofree char *tmp = NULL;
     g_autoptr(virDomainDef) def = NULL;
-    int max_available_isa_serial_ports = 4;
-    long long int used_serial_port_buffer = 0;
+    uint8_t used_serial_port_buffer = 0;
     int isa_serial_count = 0;
     int next_available_serial_port = 0;
     int max_serial_port = -1;
@@ -19936,7 +19936,6 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
     // Assign the ports to the devices.
     for (i = 0; i < n; i++) {
         if (def->serials[i]->target.port != -1) continue;
-
         // Assign one of the unused ports from first max_available_isa_serial_ports ports
         // to isa-serial device.
         if (def->serials[i]->targetType == VIR_DOMAIN_CHR_SERIAL_TARGET_MODEL_ISA_SERIAL) {

--- a/src/conf/domain_conf.c
+++ b/src/conf/domain_conf.c
@@ -19667,6 +19667,7 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
     long long int used_serial_port_buffer = 0;
     int isa_serial_count = 0;
     int next_available_serial_port = 0;
+    int max_serial_port = -1;
 
     if (!(def = virDomainDefNew(xmlopt)))
         return NULL;
@@ -19926,6 +19927,10 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
             }
             used_serial_port_buffer |= 1<<chr->target.port;
         }
+
+        // Update max serial port used.
+        if (chr->target.port > max_serial_port)
+            max_serial_port = chr->target.port;
     }
 
     // Assign the ports to the devices.
@@ -19954,13 +19959,12 @@ virDomainDefParseXML(xmlXPathContextPtr ctxt,
             used_serial_port_buffer |= 1<<next_available_serial_port;
             def->serials[i]->target.port = next_available_serial_port;
 
+            // Update max serial port used.
+            if (def->serials[i]->target.port > max_serial_port)
+                max_serial_port = def->serials[i]->target.port;
+
         } else {
-            int maxport = -1;
-            for (j = 0; j < i; j++) {
-                if (def->serials[j]->target.port > maxport)
-                    maxport = def->serials[j]->target.port;
-            }
-            def->serials[i]->target.port = maxport + 1;
+            def->serials[i]->target.port = ++max_serial_port;
         }
     }
 

--- a/src/qemu/qemu_command.c
+++ b/src/qemu/qemu_command.c
@@ -10939,7 +10939,7 @@ qemuBuildSerialChrDeviceProps(const virDomainDef *def,
 
     if (serial->targetModel == VIR_DOMAIN_CHR_SERIAL_TARGET_MODEL_ISA_SERIAL &&
                     serial->target.port != -1) {
-            if (virJSONValueObjectCreate(&props,
+            if (virJSONValueObjectAdd(&props,
                                  "s:driver", virDomainChrSerialTargetModelTypeToString(serial->targetModel),
                                  "s:chardev", chardev,
                                  "s:id", serial->info.alias,
@@ -10947,7 +10947,7 @@ qemuBuildSerialChrDeviceProps(const virDomainDef *def,
                                  NULL) < 0)
                     return NULL;
     }
-    else if (virJSONValueObjectCreate(&props,
+    else if (virJSONValueObjectAdd(&props,
                                  "s:driver", virDomainChrSerialTargetModelTypeToString(serial->targetModel),
                                  "s:chardev", chardev,
                                  "s:id", serial->info.alias,

--- a/src/qemu/qemu_command.c
+++ b/src/qemu/qemu_command.c
@@ -10937,11 +10937,21 @@ qemuBuildSerialChrDeviceProps(const virDomainDef *def,
         return NULL;
     }
 
-    if (virJSONValueObjectAdd(&props,
-                              "s:driver", virDomainChrSerialTargetModelTypeToString(serial->targetModel),
-                              "s:chardev", chardev,
-                              "s:id", serial->info.alias,
-                              NULL) < 0)
+    if (serial->targetModel == VIR_DOMAIN_CHR_SERIAL_TARGET_MODEL_ISA_SERIAL &&
+                    serial->target.port != -1) {
+            if (virJSONValueObjectCreate(&props,
+                                 "s:driver", virDomainChrSerialTargetModelTypeToString(serial->targetModel),
+                                 "s:chardev", chardev,
+                                 "s:id", serial->info.alias,
+                                 "i:index", serial->target.port,
+                                 NULL) < 0)
+                    return NULL;
+    }
+    else if (virJSONValueObjectCreate(&props,
+                                 "s:driver", virDomainChrSerialTargetModelTypeToString(serial->targetModel),
+                                 "s:chardev", chardev,
+                                 "s:id", serial->info.alias,
+                                 NULL) < 0)
         return NULL;
 
     if (qemuBuildDeviceAddressProps(props, def, &serial->info) < 0)

--- a/tests/qemuhotplugtest.c
+++ b/tests/qemuhotplugtest.c
@@ -355,7 +355,6 @@ testQemuHotplug(const void *data)
     if (keep) {
         test->vm = vm;
     } else {
-        virObjectUnref(vm);
         test->vm = NULL;
     }
     virDomainDeviceDefFree(dev);

--- a/tests/qemuhotplugtestdomains/qemuhotplug-console-compat-2-live+console-virtio.xml
+++ b/tests/qemuhotplugtestdomains/qemuhotplug-console-compat-2-live+console-virtio.xml
@@ -74,7 +74,7 @@
       <alias name='serial0'/>
     </serial>
     <serial type='pty'>
-      <target type='isa-serial' port='0'>
+      <target type='isa-serial' port='1'>
         <model name='isa-serial'/>
       </target>
       <alias name='serial1'/>
@@ -82,7 +82,7 @@
     <serial type='tcp'>
       <source mode='bind' host='0.0.0.0' service='2445'/>
       <protocol type='raw'/>
-      <target type='isa-serial' port='1'>
+      <target type='isa-serial' port='2'>
         <model name='isa-serial'/>
       </target>
       <alias name='serial2'/>

--- a/tests/qemuhotplugtestdomains/qemuhotplug-console-compat-2-live.xml
+++ b/tests/qemuhotplugtestdomains/qemuhotplug-console-compat-2-live.xml
@@ -74,7 +74,7 @@
       <alias name='serial0'/>
     </serial>
     <serial type='pty'>
-      <target type='isa-serial' port='0'>
+      <target type='isa-serial' port='1'>
         <model name='isa-serial'/>
       </target>
       <alias name='serial1'/>
@@ -82,7 +82,7 @@
     <serial type='tcp'>
       <source mode='bind' host='0.0.0.0' service='2445'/>
       <protocol type='raw'/>
-      <target type='isa-serial' port='1'>
+      <target type='isa-serial' port='2'>
         <model name='isa-serial'/>
       </target>
       <alias name='serial2'/>

--- a/tests/qemuxml2argvdata/bios.args
+++ b/tests/qemuxml2argvdata/bios.args
@@ -30,7 +30,7 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device usb-tablet,id=input0,bus=usb.0,port=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/console-compat-auto.args
+++ b/tests/qemuxml2argvdata/console-compat-auto.args
@@ -29,6 +29,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/console-compat-chardev.args
+++ b/tests/qemuxml2argvdata/console-compat-chardev.args
@@ -29,6 +29,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/console-compat.args
+++ b/tests/qemuxml2argvdata/console-compat.args
@@ -29,5 +29,5 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/console-virtio-many.args
+++ b/tests/qemuxml2argvdata/console-virtio-many.args
@@ -30,7 +30,7 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev pty,id=charconsole1 \
 -device virtconsole,chardev=charconsole1,id=console1 \
 -chardev pty,id=charconsole2 \

--- a/tests/qemuxml2argvdata/controller-order.args
+++ b/tests/qemuxml2argvdata/controller-order.args
@@ -36,7 +36,7 @@ QEMU_AUDIO_DRV=spice \
 -chardev spicevmc,id=charsmartcard0,name=smartcard \
 -device ccid-card-passthru,chardev=charsmartcard0,id=smartcard0,bus=ccid0.0 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev spicevmc,id=charchannel0,name=vdagent \
 -device virtserialport,bus=virtio-serial0.0,nr=1,chardev=charchannel0,id=channel0,name=com.redhat.spice.0 \
 -device usb-tablet,id=input0,bus=usb.0,port=1.2 \

--- a/tests/qemuxml2argvdata/name-escape.x86_64-2.11.0.args
+++ b/tests/qemuxml2argvdata/name-escape.x86_64-2.11.0.args
@@ -31,9 +31,9 @@ QEMU_AUDIO_DRV=spice \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1,write-cache=on \
 -device ccid-card-emulated,backend=certificates,cert1=cert1,,foo,cert2=cert2,cert3=cert3,db=/etc/pki/nssdb,,foo,id=smartcard0,bus=ccid0.0 \
 -chardev tty,id=charserial0,path=/dev/ttyS2,,foo \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=1 \
 -chardev file,id=charserial1,path=/tmp/serial.log,,foo,append=on \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=0 \
 -chardev pipe,id=charchannel0,path=/tmp/guestfwd,,foo \
 -netdev user,guestfwd=tcp:10.0.2.1:4600-chardev:charchannel0,id=channel0 \
 -vnc vnc=unix:/tmp/lib/domain--1-foo=1,,bar=2/vnc.sock \

--- a/tests/qemuxml2argvdata/name-escape.xml
+++ b/tests/qemuxml2argvdata/name-escape.xml
@@ -43,7 +43,7 @@
     </graphics>
     <serial type='dev'>
       <source path='/dev/ttyS2,foo'/>
-      <target port='1'/>
+      <target/>
     </serial>
     <serial type='file'>
       <source path='/tmp/serial.log,foo' append='on'/>

--- a/tests/qemuxml2argvdata/name-escape.xml
+++ b/tests/qemuxml2argvdata/name-escape.xml
@@ -43,6 +43,7 @@
     </graphics>
     <serial type='dev'>
       <source path='/dev/ttyS2,foo'/>
+      <target port='1'/>
     </serial>
     <serial type='file'>
       <source path='/tmp/serial.log,foo' append='on'/>

--- a/tests/qemuxml2argvdata/q35-virt-manager-basic.args
+++ b/tests/qemuxml2argvdata/q35-virt-manager-basic.args
@@ -39,7 +39,7 @@ QEMU_AUDIO_DRV=spice \
 -netdev user,id=hostnet0 \
 -device virtio-net-pci,netdev=hostnet0,id=net0,mac=52:54:00:9a:e6:c6,bus=pci.1,addr=0x0 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev socket,id=charchannel0,path=/tmp/channel/domain--1-virt-manager-basic/org.qemu.guest_agent.0,server=on,wait=off \
 -device virtserialport,bus=virtio-serial0.0,nr=1,chardev=charchannel0,id=channel0,name=org.qemu.guest_agent.0 \
 -chardev spicevmc,id=charchannel1,name=vdagent \

--- a/tests/qemuxml2argvdata/serial-dev-chardev-iobase.args
+++ b/tests/qemuxml2argvdata/serial-dev-chardev-iobase.args
@@ -29,6 +29,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev tty,id=charserial0,path=/dev/ttyS2 \
--device isa-serial,chardev=charserial0,id=serial0,iobase=1016,irq=4 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0,iobase=1016,irq=4 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-dev-chardev.args
+++ b/tests/qemuxml2argvdata/serial-dev-chardev.args
@@ -29,6 +29,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev tty,id=charserial0,path=/dev/ttyS2 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-file-chardev.args
+++ b/tests/qemuxml2argvdata/serial-file-chardev.args
@@ -29,6 +29,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev file,id=charserial0,path=/tmp/serial.log,append=on \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-file-log.args
+++ b/tests/qemuxml2argvdata/serial-file-log.args
@@ -29,5 +29,5 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev file,id=charserial0,path=/tmp/serial.log,logfile=/var/lib/libvirt/qemu/demo-serial.log,logappend=off \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-many-chardev.args
+++ b/tests/qemuxml2argvdata/serial-many-chardev.args
@@ -29,8 +29,8 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev file,id=charserial1,path=/tmp/serial.log \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-pty-chardev.args
+++ b/tests/qemuxml2argvdata/serial-pty-chardev.args
@@ -29,6 +29,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-spiceport.args
+++ b/tests/qemuxml2argvdata/serial-spiceport.args
@@ -28,7 +28,7 @@ QEMU_AUDIO_DRV=spice \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev spiceport,id=charserial0,name=org.qemu.console.serial.0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device usb-tablet,id=input0,bus=usb.0,port=1 \
 -spice port=5903,tls-port=5904,addr=127.0.0.1,x509-dir=/etc/pki/libvirt-spice,seamless-migration=on \
 -device qxl-vga,id=video0,ram_size=67108864,vram_size=67108864,bus=pci.0,addr=0x2 \

--- a/tests/qemuxml2argvdata/serial-tcp-chardev.args
+++ b/tests/qemuxml2argvdata/serial-tcp-chardev.args
@@ -29,6 +29,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev socket,id=charserial0,host=127.0.0.1,port=9999 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-telnet-chardev.args
+++ b/tests/qemuxml2argvdata/serial-tcp-telnet-chardev.args
@@ -29,6 +29,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev socket,id=charserial0,host=127.0.0.1,port=9999,telnet=on,server=on,wait=off \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-notls.args
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-notls.args
@@ -29,8 +29,12 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=2222,localaddr=127.0.0.1,localport=1111 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=2 \
 -chardev socket,id=charserial1,host=127.0.0.1,port=5555 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=0 \
+-chardev socket,id=charserial2,host=127.0.0.1,port=5555 \
+-device isa-serial,chardev=charserial2,id=serial2,index=1 \
+-chardev socket,id=charserial3,host=127.0.0.1,port=5555 \
+-device isa-serial,chardev=charserial3,id=serial3,index=3 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x3 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-notls.xml
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-notls.xml
@@ -30,7 +30,7 @@
     <serial type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>
       <source mode='connect' host='127.0.0.1' service='2222'/>
-      <target type='isa-serial' port='0'>
+      <target type='isa-serial' port='2'>
         <model name='isa-serial'/>
       </target>
     </serial>
@@ -41,10 +41,24 @@
         <model name='isa-serial'/>
       </target>
     </serial>
+    <serial type='tcp'>
+      <source mode='connect' host='127.0.0.1' service='5555' tls='no'/>
+      <protocol type='raw'/>
+      <target type='isa-serial' port='1'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <serial type='tcp'>
+      <source mode='connect' host='127.0.0.1' service='5555' tls='no'/>
+      <protocol type='raw'/>
+      <target type='isa-serial' port='3'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
     <console type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>
       <source mode='connect' host='127.0.0.1' service='2222'/>
-      <target type='serial' port='0'/>
+      <target type='serial' port='2'/>
     </console>
     <input type='mouse' bus='ps2'/>
     <input type='keyboard' bus='ps2'/>

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-verify.args
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-verify.args
@@ -29,9 +29,9 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=2222,localaddr=127.0.0.1,localport=1111 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -object tls-creds-x509,id=objcharserial1_tls0,dir=/etc/pki/libvirt-chardev,endpoint=client,verify-peer=on \
 -chardev socket,id=charserial1,host=127.0.0.1,port=5555,tls-creds=objcharserial1_tls0 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-verify.xml
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-verify.xml
@@ -29,7 +29,7 @@
     <serial type='tcp'>
       <source mode='connect' host='127.0.0.1' service='5555'/>
       <protocol type='raw'/>
-      <target port='0'/>
+      <target port='1'/>
     </serial>
     <console type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev.args
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev.args
@@ -29,9 +29,9 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=2222,localaddr=127.0.0.1,localport=1111 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -object tls-creds-x509,id=objcharserial1_tls0,dir=/etc/pki/libvirt-chardev,endpoint=client,verify-peer=on \
 -chardev socket,id=charserial1,host=127.0.0.1,port=5555,tls-creds=objcharserial1_tls0 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev.xml
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev.xml
@@ -29,7 +29,7 @@
     <serial type='tcp'>
       <source mode='connect' host='127.0.0.1' service='5555'/>
       <protocol type='raw'/>
-      <target port='0'/>
+      <target port='1'/>
     </serial>
     <console type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-secret-chardev.args
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-secret-chardev.args
@@ -29,10 +29,10 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=2222,localaddr=127.0.0.1,localport=1111 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -object secret,id=charserial1-secret0,data=9eao5F8qtkGt+seB1HYivWIxbtwUu6MQtg1zpj/oDtUsPr1q8wBYM91uEHCn6j/1,keyid=masterKey0,iv=AAECAwQFBgcICQoLDA0ODw==,format=base64 \
 -object tls-creds-x509,id=objcharserial1_tls0,dir=/etc/pki/libvirt-chardev,endpoint=client,verify-peer=on,passwordid=charserial1-secret0 \
 -chardev socket,id=charserial1,host=127.0.0.1,port=5555,tls-creds=objcharserial1_tls0 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x3 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-secret-chardev.xml
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-secret-chardev.xml
@@ -34,7 +34,7 @@
     <serial type='tcp'>
       <source mode='connect' host='127.0.0.1' service='5555'/>
       <protocol type='raw'/>
-      <target port='0'/>
+      <target port='1'/>
     </serial>
     <console type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>

--- a/tests/qemuxml2argvdata/serial-udp-chardev.args
+++ b/tests/qemuxml2argvdata/serial-udp-chardev.args
@@ -29,8 +29,8 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=9998,localaddr=127.0.0.1,localport=9999 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev udp,id=charserial1,host=,port=9999,localaddr=,localport=0 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-unix-chardev.args
+++ b/tests/qemuxml2argvdata/serial-unix-chardev.args
@@ -27,8 +27,8 @@ QEMU_AUDIO_DRV=none \
 -boot strict=on \
 -usb \
 -chardev socket,id=charserial0,path=/tmp/serial.sock \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev socket,id=charserial1,path=/tmp/serial-server.sock,server=on,wait=off \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-unix-chardev.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/serial-unix-chardev.x86_64-latest.args
@@ -28,9 +28,9 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-QEMUGuest1/.config \
 -boot strict=on \
 -device '{"driver":"piix3-usb-uhci","id":"usb","bus":"pci.0","addr":"0x1.0x2"}' \
 -chardev socket,id=charserial0,path=/tmp/serial.sock \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charserial1,fd=1729,server=on,wait=off \
--device '{"driver":"isa-serial","chardev":"charserial1","id":"serial1"}' \
+-device '{"driver":"isa-serial","chardev":"charserial1","id":"serial1","index":1}' \
 -audiodev '{"id":"audio1","driver":"none"}' \
 -device '{"driver":"virtio-balloon-pci","id":"balloon0","bus":"pci.0","addr":"0x2"}' \
 -sandbox on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny \

--- a/tests/qemuxml2argvdata/serial-vc-chardev.args
+++ b/tests/qemuxml2argvdata/serial-vc-chardev.args
@@ -29,6 +29,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev vc,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/user-aliases.args
+++ b/tests/qemuxml2argvdata/user-aliases.args
@@ -54,9 +54,9 @@ QEMU_AUDIO_DRV=none \
 -device rtl8139,netdev=hostua-AndAlsoClientMode,id=ua-AndAlsoClientMode,mac=52:54:00:8c:b1:f8,bus=pci.0,addr=0xa \
 -device ccid-card-emulated,backend=nss-emulated,id=smartcard0,bus=ua-myCCID.0 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev pty,id=charserial1 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -chardev socket,id=charchannel0,path=/var/lib/libvirt/qemu/channel/target/gentoo.org.qemu.guest_agent.0,server=on,wait=off \
 -device virtserialport,bus=virtio-serial0.0,nr=1,chardev=charchannel0,id=channel0,name=org.qemu.guest_agent.0 \
 -vnc 127.0.0.1:0 \

--- a/tests/qemuxml2argvdata/virtio-9p-createmode.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/virtio-9p-createmode.x86_64-latest.args
@@ -36,7 +36,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-QEMUGuest1/.config \
 -fsdev local,security_model=mapped,id=fsdev-fs3,path=/export/fs3 \
 -device '{"driver":"virtio-9p-pci","id":"fs3","fsdev":"fsdev-fs3","mount_tag":"fs3","bus":"pci.0","addr":"0x5"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -audiodev '{"id":"audio1","driver":"none"}' \
 -device '{"driver":"virtio-balloon-pci","id":"balloon0","bus":"pci.0","addr":"0xc"}' \
 -sandbox on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny \

--- a/tests/qemuxml2argvdata/virtio-9p-multidevs.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/virtio-9p-multidevs.x86_64-latest.args
@@ -34,7 +34,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-QEMUGuest1/.config \
 -fsdev local,security_model=mapped,multidevs=warn,id=fsdev-fs2,path=/export/fs2 \
 -device '{"driver":"virtio-9p-pci","id":"fs2","fsdev":"fsdev-fs2","mount_tag":"fs2","bus":"pci.0","addr":"0x4"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -audiodev '{"id":"audio1","driver":"none"}' \
 -device '{"driver":"virtio-balloon-pci","id":"balloon0","bus":"pci.0","addr":"0xc"}' \
 -sandbox on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny \

--- a/tests/qemuxml2argvdata/x86_64-pc-graphics.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/x86_64-pc-graphics.x86_64-latest.args
@@ -36,7 +36,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-guest/.config \
 -netdev user,id=hostnet0 \
 -device '{"driver":"virtio-net-pci","netdev":"hostnet0","id":"net0","mac":"52:54:00:4c:e3:86","bus":"pci.0","addr":"0x3"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charchannel0,fd=1729,server=on,wait=off \
 -device '{"driver":"virtserialport","bus":"virtio-serial0.0","nr":1,"chardev":"charchannel0","id":"channel0","name":"org.qemu.guest_agent.0"}' \
 -device '{"driver":"usb-tablet","id":"input0","bus":"usb.0","port":"1"}' \

--- a/tests/qemuxml2argvdata/x86_64-pc-headless.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/x86_64-pc-headless.x86_64-latest.args
@@ -37,7 +37,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-guest/.config \
 -netdev user,id=hostnet0 \
 -device '{"driver":"virtio-net-pci","netdev":"hostnet0","id":"net0","mac":"52:54:00:09:a4:37","bus":"pci.0","addr":"0x2"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charchannel0,fd=1729,server=on,wait=off \
 -device '{"driver":"virtserialport","bus":"virtio-serial0.0","nr":1,"chardev":"charchannel0","id":"channel0","name":"org.qemu.guest_agent.0"}' \
 -audiodev '{"id":"audio1","driver":"none"}' \

--- a/tests/qemuxml2argvdata/x86_64-q35-graphics.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/x86_64-q35-graphics.x86_64-latest.args
@@ -43,7 +43,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-guest/.config \
 -netdev user,id=hostnet0 \
 -device '{"driver":"virtio-net-pci","netdev":"hostnet0","id":"net0","mac":"52:54:00:d2:70:0b","bus":"pci.1","addr":"0x0"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charchannel0,fd=1729,server=on,wait=off \
 -device '{"driver":"virtserialport","bus":"virtio-serial0.0","nr":1,"chardev":"charchannel0","id":"channel0","name":"org.qemu.guest_agent.0"}' \
 -device '{"driver":"usb-tablet","id":"input0","bus":"usb.0","port":"1"}' \

--- a/tests/qemuxml2argvdata/x86_64-q35-headless.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/x86_64-q35-headless.x86_64-latest.args
@@ -44,7 +44,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-guest/.config \
 -netdev user,id=hostnet0 \
 -device '{"driver":"virtio-net-pci","netdev":"hostnet0","id":"net0","mac":"52:54:00:09:a4:37","bus":"pci.1","addr":"0x0"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charchannel0,fd=1729,server=on,wait=off \
 -device '{"driver":"virtserialport","bus":"virtio-serial0.0","nr":1,"chardev":"charchannel0","id":"channel0","name":"org.qemu.guest_agent.0"}' \
 -audiodev '{"id":"audio1","driver":"none"}' \

--- a/tests/qemuxml2xmloutdata/serial-tcp-tlsx509-chardev.xml
+++ b/tests/qemuxml2xmloutdata/serial-tcp-tlsx509-chardev.xml
@@ -37,7 +37,7 @@
     <serial type='tcp'>
       <source mode='connect' host='127.0.0.1' service='5555'/>
       <protocol type='raw'/>
-      <target type='isa-serial' port='0'>
+      <target type='isa-serial' port='1'>
         <model name='isa-serial'/>
       </target>
     </serial>


### PR DESCRIPTION
- If we want two isa-serial devices and for the first one is we mention the port to be 3, then for the next device it not automatically assign the port number  4 which is not supported for isa-serial devices. But we are left with 3 ports (0,1,2) which are unused. So ideally we should have used them.
- It is possible that two devices get the same port address which might lead to a lot of ambiguity. Example: we want two devices and for the second one we provide the index 0. Then from default logic the first device will be allotted port 0 and the second device will overwrite it and get port 0.

This patch only deals for the isa-serial devices. For non isa-serial devices we will be keeping the same incremental logic.
https://docs.google.com/document/d/16qcjSmmF9cdmZNCEmzZGVrklhL7kDUl_cYp2JoHjFLs/edit#heading=h.l1l2v51nz58y
