### PR TITLE
Updated port allocation logic for isa serial devices.

### DIFF
--- a/src/qemu/qemu_command.c
+++ b/src/qemu/qemu_command.c
@@ -10953,11 +10953,20 @@ qemuBuildSerialChrDeviceProps(const virDomainDef *def,
         return NULL;
     }
 
-    if (virJSONValueObjectAdd(&props,
-                              "s:driver", virDomainChrSerialTargetModelTypeToString(serial->targetModel),
-                              "s:chardev", chardev,
-                              "s:id", serial->info.alias,
-                              NULL) < 0)
+    if (serial->targetModel == VIR_DOMAIN_CHR_SERIAL_TARGET_MODEL_ISA_SERIAL) {
+            if (virJSONValueObjectAdd(&props,
+                                 "s:driver", virDomainChrSerialTargetModelTypeToString(serial->targetModel),
+                                 "s:chardev", chardev,
+                                 "s:id", serial->info.alias,
+                                 "k:index", serial->target.port,
+                                 NULL) < 0)
+                    return NULL;
+    }
+    else if (virJSONValueObjectAdd(&props,
+                                 "s:driver", virDomainChrSerialTargetModelTypeToString(serial->targetModel),
+                                 "s:chardev", chardev,
+                                 "s:id", serial->info.alias,
+                                 NULL) < 0)
         return NULL;
 
     if (qemuBuildDeviceAddressProps(props, def, &serial->info) < 0)

--- a/tests/qemuhotplugtestdomains/qemuhotplug-console-compat-2-live+console-virtio.xml
+++ b/tests/qemuhotplugtestdomains/qemuhotplug-console-compat-2-live+console-virtio.xml
@@ -74,7 +74,7 @@
       <alias name='serial0'/>
     </serial>
     <serial type='pty'>
-      <target type='isa-serial' port='0'>
+      <target type='isa-serial' port='1'>
         <model name='isa-serial'/>
       </target>
       <alias name='serial1'/>
@@ -82,7 +82,7 @@
     <serial type='tcp'>
       <source mode='bind' host='0.0.0.0' service='2445'/>
       <protocol type='raw'/>
-      <target type='isa-serial' port='1'>
+      <target type='isa-serial' port='2'>
         <model name='isa-serial'/>
       </target>
       <alias name='serial2'/>

--- a/tests/qemuhotplugtestdomains/qemuhotplug-console-compat-2-live.xml
+++ b/tests/qemuhotplugtestdomains/qemuhotplug-console-compat-2-live.xml
@@ -74,7 +74,7 @@
       <alias name='serial0'/>
     </serial>
     <serial type='pty'>
-      <target type='isa-serial' port='0'>
+      <target type='isa-serial' port='1'>
         <model name='isa-serial'/>
       </target>
       <alias name='serial1'/>
@@ -82,7 +82,7 @@
     <serial type='tcp'>
       <source mode='bind' host='0.0.0.0' service='2445'/>
       <protocol type='raw'/>
-      <target type='isa-serial' port='1'>
+      <target type='isa-serial' port='2'>
         <model name='isa-serial'/>
       </target>
       <alias name='serial2'/>

--- a/tests/qemuxml2argvdata/bios.args
+++ b/tests/qemuxml2argvdata/bios.args
@@ -31,7 +31,7 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device usb-tablet,id=input0,bus=usb.0,port=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/console-compat-auto.args
+++ b/tests/qemuxml2argvdata/console-compat-auto.args
@@ -30,6 +30,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/console-compat-chardev.args
+++ b/tests/qemuxml2argvdata/console-compat-chardev.args
@@ -30,6 +30,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/console-compat.args
+++ b/tests/qemuxml2argvdata/console-compat.args
@@ -30,5 +30,5 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/console-virtio-many.args
+++ b/tests/qemuxml2argvdata/console-virtio-many.args
@@ -31,7 +31,7 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev pty,id=charconsole1 \
 -device virtconsole,chardev=charconsole1,id=console1 \
 -chardev pty,id=charconsole2 \

--- a/tests/qemuxml2argvdata/controller-order.args
+++ b/tests/qemuxml2argvdata/controller-order.args
@@ -37,7 +37,7 @@ QEMU_AUDIO_DRV=spice \
 -chardev spicevmc,id=charsmartcard0,name=smartcard \
 -device ccid-card-passthru,chardev=charsmartcard0,id=smartcard0,bus=ccid0.0 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev spicevmc,id=charchannel0,name=vdagent \
 -device virtserialport,bus=virtio-serial0.0,nr=1,chardev=charchannel0,id=channel0,name=com.redhat.spice.0 \
 -device usb-tablet,id=input0,bus=usb.0,port=1.2 \

--- a/tests/qemuxml2argvdata/name-escape.x86_64-2.11.0.args
+++ b/tests/qemuxml2argvdata/name-escape.x86_64-2.11.0.args
@@ -32,9 +32,9 @@ QEMU_AUDIO_DRV=spice \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1,write-cache=on \
 -device ccid-card-emulated,backend=certificates,cert1=cert1,,foo,cert2=cert2,cert3=cert3,db=/etc/pki/nssdb,,foo,id=smartcard0,bus=ccid0.0 \
 -chardev tty,id=charserial0,path=/dev/ttyS2,,foo \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=1 \
 -chardev file,id=charserial1,path=/tmp/serial.log,,foo,append=on \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=0 \
 -chardev pipe,id=charchannel0,path=/tmp/guestfwd,,foo \
 -netdev user,guestfwd=tcp:10.0.2.1:4600-chardev:charchannel0,id=channel0 \
 -vnc vnc=unix:/tmp/lib/domain--1-foo=1,,bar=2/vnc.sock \

--- a/tests/qemuxml2argvdata/name-escape.xml
+++ b/tests/qemuxml2argvdata/name-escape.xml
@@ -43,6 +43,7 @@
     </graphics>
     <serial type='dev'>
       <source path='/dev/ttyS2,foo'/>
+      <target/>
     </serial>
     <serial type='file'>
       <source path='/tmp/serial.log,foo' append='on'/>

--- a/tests/qemuxml2argvdata/q35-virt-manager-basic.args
+++ b/tests/qemuxml2argvdata/q35-virt-manager-basic.args
@@ -40,7 +40,7 @@ QEMU_AUDIO_DRV=spice \
 -netdev user,id=hostnet0 \
 -device virtio-net-pci,netdev=hostnet0,id=net0,mac=52:54:00:9a:e6:c6,bus=pci.1,addr=0x0 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev socket,id=charchannel0,path=/tmp/channel/domain--1-virt-manager-basic/org.qemu.guest_agent.0,server=on,wait=off \
 -device virtserialport,bus=virtio-serial0.0,nr=1,chardev=charchannel0,id=channel0,name=org.qemu.guest_agent.0 \
 -chardev spicevmc,id=charchannel1,name=vdagent \

--- a/tests/qemuxml2argvdata/serial-dev-chardev-iobase.args
+++ b/tests/qemuxml2argvdata/serial-dev-chardev-iobase.args
@@ -30,6 +30,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev tty,id=charserial0,path=/dev/ttyS2 \
--device isa-serial,chardev=charserial0,id=serial0,iobase=1016,irq=4 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0,iobase=1016,irq=4 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-dev-chardev.args
+++ b/tests/qemuxml2argvdata/serial-dev-chardev.args
@@ -30,6 +30,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev tty,id=charserial0,path=/dev/ttyS2 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-file-chardev.args
+++ b/tests/qemuxml2argvdata/serial-file-chardev.args
@@ -30,6 +30,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev file,id=charserial0,path=/tmp/serial.log,append=on \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-file-log.args
+++ b/tests/qemuxml2argvdata/serial-file-log.args
@@ -30,5 +30,5 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev file,id=charserial0,path=/tmp/serial.log,logfile=/var/lib/libvirt/qemu/demo-serial.log,logappend=off \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-many-chardev.args
+++ b/tests/qemuxml2argvdata/serial-many-chardev.args
@@ -30,8 +30,8 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev file,id=charserial1,path=/tmp/serial.log \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-pty-chardev.args
+++ b/tests/qemuxml2argvdata/serial-pty-chardev.args
@@ -30,6 +30,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-spiceport.args
+++ b/tests/qemuxml2argvdata/serial-spiceport.args
@@ -29,7 +29,7 @@ QEMU_AUDIO_DRV=spice \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev spiceport,id=charserial0,name=org.qemu.console.serial.0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device usb-tablet,id=input0,bus=usb.0,port=1 \
 -spice port=5903,tls-port=5904,addr=127.0.0.1,x509-dir=/etc/pki/libvirt-spice,seamless-migration=on \
 -device qxl-vga,id=video0,ram_size=67108864,vram_size=67108864,bus=pci.0,addr=0x2 \

--- a/tests/qemuxml2argvdata/serial-tcp-chardev.args
+++ b/tests/qemuxml2argvdata/serial-tcp-chardev.args
@@ -30,6 +30,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev socket,id=charserial0,host=127.0.0.1,port=9999 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-telnet-chardev.args
+++ b/tests/qemuxml2argvdata/serial-tcp-telnet-chardev.args
@@ -30,6 +30,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev socket,id=charserial0,host=127.0.0.1,port=9999,telnet=on,server=on,wait=off \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-notls.args
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-notls.args
@@ -30,8 +30,12 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=2222,localaddr=127.0.0.1,localport=1111 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=2 \
 -chardev socket,id=charserial1,host=127.0.0.1,port=5555 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=0 \
+-chardev socket,id=charserial2,host=127.0.0.1,port=5555 \
+-device isa-serial,chardev=charserial2,id=serial2,index=1 \
+-chardev socket,id=charserial3,host=127.0.0.1,port=5555 \
+-device isa-serial,chardev=charserial3,id=serial3,index=3 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x3 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-notls.xml
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-notls.xml
@@ -30,7 +30,7 @@
     <serial type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>
       <source mode='connect' host='127.0.0.1' service='2222'/>
-      <target type='isa-serial' port='0'>
+      <target type='isa-serial' port='2'>
         <model name='isa-serial'/>
       </target>
     </serial>
@@ -41,10 +41,24 @@
         <model name='isa-serial'/>
       </target>
     </serial>
+    <serial type='tcp'>
+      <source mode='connect' host='127.0.0.1' service='5555' tls='no'/>
+      <protocol type='raw'/>
+      <target type='isa-serial' port='1'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
+    <serial type='tcp'>
+      <source mode='connect' host='127.0.0.1' service='5555' tls='no'/>
+      <protocol type='raw'/>
+      <target type='isa-serial' port='3'>
+        <model name='isa-serial'/>
+      </target>
+    </serial>
     <console type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>
       <source mode='connect' host='127.0.0.1' service='2222'/>
-      <target type='serial' port='0'/>
+      <target type='serial' port='2'/>
     </console>
     <input type='mouse' bus='ps2'/>
     <input type='keyboard' bus='ps2'/>

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-verify.args
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-verify.args
@@ -30,9 +30,9 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=2222,localaddr=127.0.0.1,localport=1111 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -object tls-creds-x509,id=objcharserial1_tls0,dir=/etc/pki/libvirt-chardev,endpoint=client,verify-peer=on \
 -chardev socket,id=charserial1,host=127.0.0.1,port=5555,tls-creds=objcharserial1_tls0 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-verify.xml
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev-verify.xml
@@ -29,7 +29,7 @@
     <serial type='tcp'>
       <source mode='connect' host='127.0.0.1' service='5555'/>
       <protocol type='raw'/>
-      <target port='0'/>
+      <target port='1'/>
     </serial>
     <console type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev.args
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev.args
@@ -30,9 +30,9 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=2222,localaddr=127.0.0.1,localport=1111 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -object tls-creds-x509,id=objcharserial1_tls0,dir=/etc/pki/libvirt-chardev,endpoint=client,verify-peer=on \
 -chardev socket,id=charserial1,host=127.0.0.1,port=5555,tls-creds=objcharserial1_tls0 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev.xml
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-chardev.xml
@@ -29,7 +29,7 @@
     <serial type='tcp'>
       <source mode='connect' host='127.0.0.1' service='5555'/>
       <protocol type='raw'/>
-      <target port='0'/>
+      <target port='1'/>
     </serial>
     <console type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-secret-chardev.args
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-secret-chardev.args
@@ -30,10 +30,10 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=2222,localaddr=127.0.0.1,localport=1111 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -object secret,id=charserial1-secret0,data=9eao5F8qtkGt+seB1HYivWIxbtwUu6MQtg1zpj/oDtUsPr1q8wBYM91uEHCn6j/1,keyid=masterKey0,iv=AAECAwQFBgcICQoLDA0ODw==,format=base64 \
 -object tls-creds-x509,id=objcharserial1_tls0,dir=/etc/pki/libvirt-chardev,endpoint=client,verify-peer=on,passwordid=charserial1-secret0 \
 -chardev socket,id=charserial1,host=127.0.0.1,port=5555,tls-creds=objcharserial1_tls0 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x3 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-tcp-tlsx509-secret-chardev.xml
+++ b/tests/qemuxml2argvdata/serial-tcp-tlsx509-secret-chardev.xml
@@ -34,7 +34,7 @@
     <serial type='tcp'>
       <source mode='connect' host='127.0.0.1' service='5555'/>
       <protocol type='raw'/>
-      <target port='0'/>
+      <target port='1'/>
     </serial>
     <console type='udp'>
       <source mode='bind' host='127.0.0.1' service='1111'/>

--- a/tests/qemuxml2argvdata/serial-udp-chardev.args
+++ b/tests/qemuxml2argvdata/serial-udp-chardev.args
@@ -30,8 +30,8 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev udp,id=charserial0,host=127.0.0.1,port=9998,localaddr=127.0.0.1,localport=9999 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev udp,id=charserial1,host=,port=9999,localaddr=,localport=0 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-unix-chardev.args
+++ b/tests/qemuxml2argvdata/serial-unix-chardev.args
@@ -28,8 +28,8 @@ QEMU_AUDIO_DRV=none \
 -boot strict=on \
 -usb \
 -chardev socket,id=charserial0,path=/tmp/serial.sock \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev socket,id=charserial1,path=/tmp/serial-server.sock,server=on,wait=off \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/serial-unix-chardev.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/serial-unix-chardev.x86_64-latest.args
@@ -29,9 +29,9 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-QEMUGuest1/.config \
 -boot strict=on \
 -device '{"driver":"piix3-usb-uhci","id":"usb","bus":"pci.0","addr":"0x1.0x2"}' \
 -chardev socket,id=charserial0,path=/tmp/serial.sock \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charserial1,fd=1729,server=on,wait=off \
--device '{"driver":"isa-serial","chardev":"charserial1","id":"serial1"}' \
+-device '{"driver":"isa-serial","chardev":"charserial1","id":"serial1","index":1}' \
 -audiodev '{"id":"audio1","driver":"none"}' \
 -device '{"driver":"virtio-balloon-pci","id":"balloon0","bus":"pci.0","addr":"0x2"}' \
 -sandbox on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny \

--- a/tests/qemuxml2argvdata/serial-vc-chardev.args
+++ b/tests/qemuxml2argvdata/serial-vc-chardev.args
@@ -30,6 +30,6 @@ QEMU_AUDIO_DRV=none \
 -drive file=/dev/HostVG/QEMUGuest1,format=raw,if=none,id=drive-ide0-0-0 \
 -device ide-hd,bus=ide.0,unit=0,drive=drive-ide0-0-0,id=ide0-0-0,bootindex=1 \
 -chardev vc,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -device virtio-balloon-pci,id=balloon0,bus=pci.0,addr=0x2 \
 -msg timestamp=on

--- a/tests/qemuxml2argvdata/user-aliases.args
+++ b/tests/qemuxml2argvdata/user-aliases.args
@@ -55,9 +55,9 @@ QEMU_AUDIO_DRV=none \
 -device rtl8139,netdev=hostua-AndAlsoClientMode,id=ua-AndAlsoClientMode,mac=52:54:00:8c:b1:f8,bus=pci.0,addr=0xa \
 -device ccid-card-emulated,backend=nss-emulated,id=smartcard0,bus=ua-myCCID.0 \
 -chardev pty,id=charserial0 \
--device isa-serial,chardev=charserial0,id=serial0 \
+-device isa-serial,chardev=charserial0,id=serial0,index=0 \
 -chardev pty,id=charserial1 \
--device isa-serial,chardev=charserial1,id=serial1 \
+-device isa-serial,chardev=charserial1,id=serial1,index=1 \
 -chardev socket,id=charchannel0,path=/var/lib/libvirt/qemu/channel/target/gentoo.org.qemu.guest_agent.0,server=on,wait=off \
 -device virtserialport,bus=virtio-serial0.0,nr=1,chardev=charchannel0,id=channel0,name=org.qemu.guest_agent.0 \
 -vnc 127.0.0.1:0 \

--- a/tests/qemuxml2argvdata/virtio-9p-createmode.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/virtio-9p-createmode.x86_64-latest.args
@@ -37,7 +37,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-QEMUGuest1/.config \
 -fsdev local,security_model=mapped,id=fsdev-fs3,path=/export/fs3 \
 -device '{"driver":"virtio-9p-pci","id":"fs3","fsdev":"fsdev-fs3","mount_tag":"fs3","bus":"pci.0","addr":"0x5"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -audiodev '{"id":"audio1","driver":"none"}' \
 -device '{"driver":"virtio-balloon-pci","id":"balloon0","bus":"pci.0","addr":"0xc"}' \
 -sandbox on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny \

--- a/tests/qemuxml2argvdata/virtio-9p-multidevs.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/virtio-9p-multidevs.x86_64-latest.args
@@ -35,7 +35,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-QEMUGuest1/.config \
 -fsdev local,security_model=mapped,multidevs=warn,id=fsdev-fs2,path=/export/fs2 \
 -device '{"driver":"virtio-9p-pci","id":"fs2","fsdev":"fsdev-fs2","mount_tag":"fs2","bus":"pci.0","addr":"0x4"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -audiodev '{"id":"audio1","driver":"none"}' \
 -device '{"driver":"virtio-balloon-pci","id":"balloon0","bus":"pci.0","addr":"0xc"}' \
 -sandbox on,obsolete=deny,elevateprivileges=deny,spawn=deny,resourcecontrol=deny \

--- a/tests/qemuxml2argvdata/x86_64-pc-graphics.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/x86_64-pc-graphics.x86_64-latest.args
@@ -37,7 +37,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-guest/.config \
 -netdev user,id=hostnet0 \
 -device '{"driver":"virtio-net-pci","netdev":"hostnet0","id":"net0","mac":"52:54:00:4c:e3:86","bus":"pci.0","addr":"0x3"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charchannel0,fd=1729,server=on,wait=off \
 -device '{"driver":"virtserialport","bus":"virtio-serial0.0","nr":1,"chardev":"charchannel0","id":"channel0","name":"org.qemu.guest_agent.0"}' \
 -device '{"driver":"usb-tablet","id":"input0","bus":"usb.0","port":"1"}' \

--- a/tests/qemuxml2argvdata/x86_64-pc-headless.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/x86_64-pc-headless.x86_64-latest.args
@@ -38,7 +38,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-guest/.config \
 -netdev user,id=hostnet0 \
 -device '{"driver":"virtio-net-pci","netdev":"hostnet0","id":"net0","mac":"52:54:00:09:a4:37","bus":"pci.0","addr":"0x2"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charchannel0,fd=1729,server=on,wait=off \
 -device '{"driver":"virtserialport","bus":"virtio-serial0.0","nr":1,"chardev":"charchannel0","id":"channel0","name":"org.qemu.guest_agent.0"}' \
 -audiodev '{"id":"audio1","driver":"none"}' \

--- a/tests/qemuxml2argvdata/x86_64-q35-graphics.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/x86_64-q35-graphics.x86_64-latest.args
@@ -44,7 +44,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-guest/.config \
 -netdev user,id=hostnet0 \
 -device '{"driver":"virtio-net-pci","netdev":"hostnet0","id":"net0","mac":"52:54:00:d2:70:0b","bus":"pci.1","addr":"0x0"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charchannel0,fd=1729,server=on,wait=off \
 -device '{"driver":"virtserialport","bus":"virtio-serial0.0","nr":1,"chardev":"charchannel0","id":"channel0","name":"org.qemu.guest_agent.0"}' \
 -device '{"driver":"usb-tablet","id":"input0","bus":"usb.0","port":"1"}' \

--- a/tests/qemuxml2argvdata/x86_64-q35-headless.x86_64-latest.args
+++ b/tests/qemuxml2argvdata/x86_64-q35-headless.x86_64-latest.args
@@ -45,7 +45,7 @@ XDG_CONFIG_HOME=/tmp/lib/domain--1-guest/.config \
 -netdev user,id=hostnet0 \
 -device '{"driver":"virtio-net-pci","netdev":"hostnet0","id":"net0","mac":"52:54:00:09:a4:37","bus":"pci.1","addr":"0x0"}' \
 -chardev pty,id=charserial0 \
--device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0"}' \
+-device '{"driver":"isa-serial","chardev":"charserial0","id":"serial0","index":0}' \
 -chardev socket,id=charchannel0,fd=1729,server=on,wait=off \
 -device '{"driver":"virtserialport","bus":"virtio-serial0.0","nr":1,"chardev":"charchannel0","id":"channel0","name":"org.qemu.guest_agent.0"}' \
 -audiodev '{"id":"audio1","driver":"none"}' \

--- a/tests/qemuxml2xmloutdata/serial-tcp-tlsx509-chardev.xml
+++ b/tests/qemuxml2xmloutdata/serial-tcp-tlsx509-chardev.xml
@@ -37,7 +37,7 @@
     <serial type='tcp'>
       <source mode='connect' host='127.0.0.1' service='5555'/>
       <protocol type='raw'/>
-      <target type='isa-serial' port='0'>
+      <target type='isa-serial' port='1'>
         <model name='isa-serial'/>
       </target>
     </serial>


### PR DESCRIPTION
Updated port allocation logic for isa serial devices. Since qemu allocates only
starting 4 ports to isa-serial device, to assign the port it will check the 4
ports availability and assign the port accordingly to that device.
It will also check if user assigned the same port to multiple devices and in
case user did, it will throw the error.

Update the code to provide index for isa-serial devices using taget.port for
the generated qemu command.

Signed-off-by: Divya Garg <divya.garg@nutanix.com>